### PR TITLE
Revamped the triggering scheme for Eiger and Xpress3. 

### DIFF
--- a/src/isn/devices/diffractometer.py
+++ b/src/isn/devices/diffractometer.py
@@ -9,7 +9,7 @@ from .robot import RobotArmPositioner
 class RobotArmDiffractometer(hklpy2.DiffractometerBase):
     """ISN Robot Arm as Diffractometer."""
 
-    _real = "mu eta chi phi pitch yaw".split()
+    _real = "mu eta chi phi yaw pitch".split()
 
     h = Cpt(hklpy2.diffract.Hklpy2PseudoAxis, "", kind="hinted")
     k = Cpt(hklpy2.diffract.Hklpy2PseudoAxis, "", kind="hinted")

--- a/src/isn/devices/me7.py
+++ b/src/isn/devices/me7.py
@@ -34,7 +34,7 @@ from .mic_ad_mixins import VortexDetectorCam
 from mic_common.utils.writeDetH5 import write_det_h5
 
 # MAX_IMAGES = 12216
-MAX_IMAGES = 500000
+MAX_IMAGES = 524288
 MAX_ROIS = 8
 DELAY = 0.2
 
@@ -62,12 +62,11 @@ class Trigger(TriggerBase):
         self._image_name = image_name
         self._acquisition_signal = self.cam.acquire
         self._acquire_busy_signal = self.cam.acquire_busy
-        # self._flysetup = False
         self._status = None
         self._delay = DELAY
         self._trigger_counter = 0
         self.cam.stage_sigs["erase_on_start"] = "No"
-        # self.setup_soft_trigger()
+        # self.setup_software_trigger()
 
     def setup_internal_trigger(self):
         self.trigger_mode = "Internal"
@@ -84,8 +83,7 @@ class Trigger(TriggerBase):
         else:
             self.hdf1.stage_sigs["enable"] = 0
             self.hdf1.stage_sigs["auto_save"] = 0
-        # self._flysetup = False
-        # self._softsetup = False
+
 
 
     def setup_external_trigger(self):
@@ -96,7 +94,7 @@ class Trigger(TriggerBase):
         self.cam.stage_sigs["num_images"] = MAX_IMAGES
         self.cam.stage_sigs["wait_for_plugins"] = "No"
 
-    def setup_soft_trigger(self):
+    def setup_software_trigger(self):
         logger.info("Configuring detector for software triggering")
         self.trigger_mode = "Software"
 
@@ -113,7 +111,6 @@ class Trigger(TriggerBase):
         else:
             self.hdf1.stage_sigs["enable"] = 0
             self.hdf1.stage_sigs["auto_save"] = 0
-        # self._softsetup = True
 
     def setup_flyscan_mode(
         self, num_images=MAX_IMAGES, acq_time=0.01, hdf_images=MAX_IMAGES
@@ -147,10 +144,10 @@ class Trigger(TriggerBase):
     def stage(self):
 
         if self.trigger_mode == "Software":
-            logger.info("Accessed software triggering staging sequence")
+            # logger.info("Accessed software triggering staging sequence")
             self._trigger_counter = 0
             self._acquire_time = self.cam.acquire_time.get()
-            self.setup_soft_trigger()
+            self.setup_software_trigger()
         elif self.trigger_mode == "Internal":
             self._acquire_time = self.cam.acquire_time.get()
             self.setup_internal_trigger()
@@ -178,7 +175,7 @@ class Trigger(TriggerBase):
 
         # if self._flysetup:
         if self.trigger_mode == "Flyscan":
-            self.setup_soft_trigger()
+            self.setup_software_trigger()
             self.set_plugins("Enable")
         elif self.trigger_mode == "Software":
             self._trigger_counter = 0
@@ -425,7 +422,7 @@ class VortexXspress37(Trigger, DetectorBase):
         super().__init__(*args, **kwargs)
 
         self.default_settings()
-        # self.setup_soft_trigger()
+        # self.setup_software_trigger()
 
     # Make this compatible with other detectors
     @property
@@ -518,6 +515,8 @@ class VortexXspress37(Trigger, DetectorBase):
             obj = getattr(self, nm)
             if "blocking_callbacks" in dir(obj):  # is it a plugin?
                 obj.stage_sigs["blocking_callbacks"] = "No"
+
+        self.setup_software_trigger()
 
     @property
     def read_rois(self):

--- a/src/isn/devices/mic_ad_mixins.py
+++ b/src/isn/devices/mic_ad_mixins.py
@@ -6,6 +6,7 @@ from ophyd import EpicsSignal
 from ophyd import EpicsSignalWithRBV
 from ophyd.areadetector import Xspress3DetectorCam
 from ophyd.areadetector.plugins import HDF5Plugin
+from ophyd.areadetector.plugins import StatsPlugin
 
 
 class VortexDetectorCam(CamMixin_V34, Xspress3DetectorCam):
@@ -44,3 +45,13 @@ class MicHDF5(HDF5Plugin):
     def unstage(self):
         self.capture.put(0)
         super().unstage()
+
+class MicStatsPlugin(StatsPlugin):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.total.kind = 'hinted'
+
+    _default_read_attrs = ('total',)
+
+    

--- a/src/isn/devices/socketserver.py
+++ b/src/isn/devices/socketserver.py
@@ -23,6 +23,10 @@ class Trigger(SingleTrigger):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    def trigger(self):
+        self.hdf1.capture.put(1)
+        super().trigger()
+
     # def trigger(self):
     #     #This one will always return True as it can't access a real Status signal
     #     if self._staged != Staged.yes:
@@ -66,10 +70,13 @@ class SocketServer(Trigger, DetectorBase):
     acquire = ADComponent(EpicsSignal, "SG1:Acquire")
     array_counter = ADComponent(EpicsSignalWithRBV, "SG1:ArrayCounter")
 
-    def setup_flyscan_mode(self, num_lines = 50000):
+    def setup_flyscan_mode(self, num_lines = 50000, hdf_images = 50000):
         self.array_counter.put(0)
-        self.hdf1.stage_sigs['num_capture'] = num_lines
-        self.hdf1.stage_sigs['capture'] = 1
+        self.hdf1.stage_sigs["enable"] = 1
+        self.hdf1.stage_sigs["auto_save"] = 1
+        self.hdf1.stage_sigs['num_capture'] = hdf_images
+        self.hdf1.stage_sigs['queue_size'] = 2e5
+        # self.hdf1.stage_sigs['capture'] = 1
 
     def write_master_h5(
         self,

--- a/src/isn/plans/flyscan_v2.py
+++ b/src/isn/plans/flyscan_v2.py
@@ -274,9 +274,13 @@ def flyscan(
         yield from bps.checkpoint()
 
         total_images = int((max(x_npts_, 1) * y_npts_) / F - 1)
+        images_per_line = int(y_npts_ / F)
+        interferometry_per_line = images_per_line * interferometer_per_pixel
         total_lines = total_images*(interferometer_per_pixel+1) # We add one to leave room for events in which more frames per line are reached
 
-        socketserver.setup_flyscan_mode(num_lines = total_lines)
+        # socketserver.setup_flyscan_mode(num_lines = total_lines)
+        # We are changing to the new structure in which we have as many position files as detector files
+        socketserver.setup_flyscan_mode(hdf_images=interferometry_per_line)
         socketserver.stage()
         socketserver.trigger()
 
@@ -291,7 +295,7 @@ def flyscan(
             detector.setup_flyscan_mode(
                 num_images=total_images,
                 acq_time=acquire_time * 1e-3,
-                hdf_images=int(y_npts_ / 0.9),
+                hdf_images=images_per_line,
             )
             detector.stage()
 
@@ -328,6 +332,8 @@ def flyscan(
         for detector in detectors:
             detector.unstage()
             detector.hdf1.unstage()
+
+        socketserver.unstage()
 
         # --- Filling up DMA for socket server acquisition --- #
 

--- a/src/mic_common/devices/eiger.py
+++ b/src/mic_common/devices/eiger.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 from ophyd import (
     ADComponent,
     Component,
@@ -6,24 +10,28 @@ from ophyd import (
 )
 
 from ophyd.areadetector import (
-    SingleTrigger,
     EigerDetectorCam, 
     DetectorBase,
     ImagePlugin,
-    StatsPlugin,
     ROIPlugin,
     ADTriggerStatus,
     Staged
 )
 
+from ophyd.areadetector.trigger_mixins import TriggerBase
+
 from apstools.utils import run_in_thread
 from isn.devices.mic_ad_mixins import MicHDF5
+from isn.devices.mic_ad_mixins import MicStatsPlugin
 from time import sleep
 
 MAX_IMAGES = 1e4
 DELAY = 0.3
 
-class Trigger(SingleTrigger):
+class Trigger(TriggerBase):
+
+    trigger_mode = "Software"
+    acquire_time = 0
 
     _status_type = ADTriggerStatus
     
@@ -32,10 +40,12 @@ class Trigger(SingleTrigger):
         self._internal_trigger = False
         self._delay = DELAY
         self._trigger_counter = 0
-        self.setup_soft_trigger()
+        # It is better if we specify on the full device level the behavior we want
+        #self.setup_internal_trigger()
 
     def setup_internal_trigger(self, num_images=None):
-        self._acquisition_signal_pv = "cam1:Acquire"
+        self.trigger_mode = "Internal"
+        # self._acquisition_signal_pv = "cam1:Acquire"
         self.cam.stage_sigs["trigger_mode"] = "Internal Series"
         self.cam.stage_sigs["manual_trigger"] = "Enable"
         if not num_images:
@@ -45,25 +55,27 @@ class Trigger(SingleTrigger):
             self.cam.stage_sigs["num_images"] = num_images
             self.cam.stage_sigs["num_triggers"] = num_images
         self.cam.stage_sigs["num_exposures"] = 1
-        self._flysetup = False
-        self._internal_trigger = False
-        self._soft_trigger = True
+        # self._flysetup = False
+        # self._internal_trigger = False
+        # self._soft_trigger = True
 
-    def setup_soft_trigger(self):
-        self._acquisition_signal_pv = "cam1:Trigger"
+    def setup_software_trigger(self):
+        self.trigger_mode = "Software"
+        # self._acquisition_signal_pv = "cam1:Trigger"
         self.cam.stage_sigs["trigger_mode"] = "Internal Series"
         self.cam.stage_sigs["manual_trigger"] = "Enable"
         self.cam.stage_sigs["num_images"] = 1
         self.cam.stage_sigs["num_triggers"] = MAX_IMAGES
         self.cam.stage_sigs.move_to_end("num_triggers", last=False)
         self.cam.stage_sigs["num_exposures"] = 1
-        self.cam.stage_sigs["acquire"] = 1
+        # self.cam.stage_sigs["acquire"] = 1
         self.hdf1.stage_sigs["num_capture"] = MAX_IMAGES
-        self._flysetup = False
-        self._internal_trigger = False
-        self._soft_trigger = True
+        # self._flysetup = False
+        # self._internal_trigger = False
+        # self._soft_trigger = True
 
     def setup_flyscan_mode(self, num_images=1, acq_time=0.01, hdf_images=MAX_IMAGES):
+        self.trigger_mode = "Flyscan"
         self.cam.stage_sigs["trigger_mode"] = "External Enable"
         self.cam.stage_sigs["num_triggers"] = num_images
         self.cam.stage_sigs.move_to_end("num_triggers", last=False)
@@ -72,13 +84,13 @@ class Trigger(SingleTrigger):
         self.cam.stage_sigs["acquire_period"]= acq_time
         self.cam.stage_sigs["manual_trigger"] = "Disable"
         self.cam.stage_sigs["num_exposures"] = 1
-        self.cam.stage_sigs["acquire"] = 1
+        # self.cam.stage_sigs["acquire"] = 1
         self.hdf1.stage_sigs["enable"] = 1
         self.hdf1.stage_sigs["auto_save"] = 1
         self.hdf1.stage_sigs["num_capture"] = hdf_images
 
 
-        self._flysetup = True
+        # self._flysetup = True
 
 
     def stage(self):
@@ -86,11 +98,16 @@ class Trigger(SingleTrigger):
 
         #Guarantee we are not collecting
         self.cam.acquire.put(0)
-        self.delay = self.cam.acquire_time.get()
-        self.delay = max(self.delay, self._delay)
-        self._trigger_counter = 0
         
         super().stage()
+
+        if self.trigger_mode == "Flyscan":
+            # self.cam.acquire.set("1").wait(timeout=10)
+            self.cam.acquire.put(1)
+            sleep(0.2)
+        elif self.trigger_mode == "Software":
+            self.acquire_time = self.cam.acquire_time.get()
+            self._trigger_counter = 0
 
 
     def trigger(self):
@@ -98,7 +115,7 @@ class Trigger(SingleTrigger):
             raise RuntimeError("This detector is not ready to trigger."
                                "Call the stage() method before triggering.")
         
-        if self._internal_trigger:
+        if self.trigger_mode == "Internal":
             super().trigger()
 
         #The following only applies to soft triggering as flyscanning never triggers.
@@ -110,7 +127,7 @@ class Trigger(SingleTrigger):
 
         @run_in_thread
         def exposure_delay(status_obj):
-            sleep(self.delay)
+            sleep(self._delay + self.acquire_time)
             status_obj.set_finished()
 
         self._status = self._status_type(self)
@@ -122,9 +139,13 @@ class Trigger(SingleTrigger):
 
     def unstage(self):
         self._status = None
-        self.cam.acquire.set(0).wait(timeout=10)
+        self.cam.acquire.set(0).wait(timeout=1)
         super().unstage()
-    
+        logger.info("Unstaged eiger.")
+
+        if self.trigger_mode == "Flyscan":
+            logger.debug("Reverting eiger to internal triggering")
+            self.setup_internal_trigger()
 
 
 class EigerCam(EigerDetectorCam):
@@ -161,6 +182,12 @@ class EigerCam(EigerDetectorCam):
 
 class Eiger(Trigger, DetectorBase):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setup_software_trigger()
+
+    _default_read_attrs = ('stats4.total',)
+
     cam = ADComponent(EigerCam, 'cam1:')
     image = ADComponent(ImagePlugin, 'image1:')
     hdf1 = ADComponent(MicHDF5, 'HDF1:')
@@ -170,11 +197,11 @@ class Eiger(Trigger, DetectorBase):
     roi2 = ADComponent(ROIPlugin, 'ROI2:')
     roi3 = ADComponent(ROIPlugin, 'ROI3:')
     roi4 = ADComponent(ROIPlugin, 'ROI4:')
-    stats1 = ADComponent(StatsPlugin, 'Stats1:')
-    stats2 = ADComponent(StatsPlugin, 'Stats2:')
-    stats3 = ADComponent(StatsPlugin, 'Stats3:')
-    stats4 = ADComponent(StatsPlugin, 'Stats4:')
-    stats5 = ADComponent(StatsPlugin, 'Stats5:')
+    stats1 = ADComponent(MicStatsPlugin, 'Stats1:')
+    stats2 = ADComponent(MicStatsPlugin, 'Stats2:')
+    stats3 = ADComponent(MicStatsPlugin, 'Stats3:')
+    stats4 = ADComponent(MicStatsPlugin, 'Stats4:')
+    stats5 = ADComponent(MicStatsPlugin, 'Stats5:')
 
 
 


### PR DESCRIPTION
We have now consolidated triggering modes in both. We will default to software triggering mode for standard scans as they minimize overhead. Included additional modifications to account for triggering issues during flyscanning in eiger device and socketserver.